### PR TITLE
Replace /var/spool/cwl with portable reference

### DIFF
--- a/cufflinks.cwl
+++ b/cufflinks.cwl
@@ -35,10 +35,8 @@ outputs:
     outputBinding:
       glob: 'genes.fpkm_tracking'
 arguments:
-  - '-o'
-  - /var/spool/cwl
-requirements:
-  - class: InlineJavascriptRequirement
+  - prefix: -o
+    valueFrom: $(runtime.outdir)
 hints:
   - class: DockerRequirement
     dockerPull: 'quay.io/biocontainers/cufflinks:2.2.1--py35_1'


### PR DESCRIPTION
`/var/spool/cwl` is not part of the CWL v1.x standards. See https://github.com/common-workflow-language/common-workflow-language/issues/674 for a discussion.